### PR TITLE
feat: ✨ add "-im" command line argument to allow for manual snapshot creation in case of errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import argparse
 import atexit
 import json
+import subprocess
+from time import sleep
 
 import multiprocess
 import os
@@ -11,6 +13,8 @@ import datetime
 
 from data.app_config import AppConfig
 from steps import all_steps
+from steps.close_nsa import CloseNSA
+from steps.wait_for_emulator_boot import WaitForEmulatorBoot
 from utils.config_utils import load_config, ensure_scripts_exist, ensure_template_exists, save_config
 from utils.emulator_utils import boot_emulator, run_adb, wait_for_shutdown, create_snapshot, delete_snapshot, request_emulator_shutdown
 from utils.script_utils import execute_script
@@ -98,6 +102,7 @@ def main():
 						help='Regenerates the configuration file (and overwrites existing ones)', default=False, action='store_true')
 	parser.add_argument('-b', '-emu', '--boot-emulator', '--emu', required=False, help='Boots the emulator', default=False, action='store_true')
 	parser.add_argument('-a', '-adb', '--run-adb', '--adb', dest='ADB_COMMAND', required=False, help='Executes a command via android debug bridge (adb)')
+	parser.add_argument('-im', '-interactive', '-interactive-mode', '--interactive', '--interactive-mode', required=False, help='Runs the scrip in interactive mode', default=False, action='store_true')
 	parser.add_argument('--disable-update-check', required=False, help='Disables update check for this single call', default=False, action='store_true')
 	parser.add_argument('-u', '-update', '--update', required=False, help='Updates the application', default=False, action='store_true')
 	args = parser.parse_args()
@@ -185,6 +190,10 @@ def main():
 		logger.info('ERROR: template_path in config does not exist. Please edit the config file and insert a valid template_path. Exiting now.')
 		sys.exit(INPUT_VALIDATION_FAILED)
 
+	run_interactive = False
+	if args.interactive:
+		run_interactive = True
+
 	start_datetime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 	logger.info(f'### Script started at {start_datetime} ###')
 
@@ -203,44 +212,112 @@ def main():
 
 		extraction_process = None
 		emulator_pid = multiprocess.Value('i', 0)
-		try:
-			extraction_process = multiprocess.Process(target=run_token_extraction,
-													  args=(app_config, all_available_steps, args.console_out, start_time, start_datetime, attempt, emulator_pid))
-			extraction_process.start()
+		if not run_interactive:
+			try:
+				extraction_process = multiprocess.Process(target=run_token_extraction,
+														  args=(app_config, all_available_steps, args.console_out, start_time, start_datetime, attempt, emulator_pid))
+				extraction_process.start()
 
-			targeted_end_time = time.time() + max(60, app_config.run_config.max_attempt_duration_seconds)
-			while time.time() < targeted_end_time and extraction_process.is_alive():
-				time.sleep(1)
+				targeted_end_time = time.time() + max(60, app_config.run_config.max_attempt_duration_seconds)
+				while time.time() < targeted_end_time and extraction_process.is_alive():
+					time.sleep(1)
 
-			if extraction_process.is_alive():
-				raise Exception(f'Extraction did not finish in time ({max(60, app_config.run_config.max_attempt_duration_seconds)} seconds), forcing restart...')
-			elif extraction_process.exitcode is not None and extraction_process.exitcode == 0:
-				sys.exit(SUCCESS)
+				if extraction_process.is_alive():
+					raise Exception(f'Extraction did not finish in time ({max(60, app_config.run_config.max_attempt_duration_seconds)} seconds), forcing restart...')
+				elif extraction_process.exitcode is not None and extraction_process.exitcode == 0:
+					sys.exit(SUCCESS)
 
-		except Exception as e:
-			logger.info(f'### Exception ###')
-			logger.info(e)
-			logger.info('')
-
-			if extraction_process is not None and extraction_process.is_alive():
-				logger.info(f'Terminating extraction process...')
-				extraction_process.terminate()
-				time.sleep(10)
-				extraction_process.kill()
-				logger.info('Process terminated.')
+			except Exception as e:
+				logger.info(f'### Exception ###')
+				logger.info(e)
 				logger.info('')
 
-			# ensure a potentially created snapshot has been deleted.
-			delete_snapshot(app_config)
-			request_emulator_shutdown(app_config)
-
-			if emulator_pid.value is not None and emulator_pid.value > 0:
-				try:
-					logger.info('Emulator process might still be alive, sending KILL signal...')
+				if extraction_process is not None and extraction_process.is_alive():
+					logger.info(f'Terminating extraction process...')
+					extraction_process.terminate()
+					time.sleep(10)
+					extraction_process.kill()
+					logger.info('Process terminated.')
 					logger.info('')
-					os.kill(emulator_pid.value, signal.SIGKILL)
-				except Exception as e2:
-					logger.info(e2)
+
+				screenshot_path = save_splanet3_screenshot(app_config)
+				log_splatnet3_screenshot_message(screenshot_path)
+
+				# ensure a potentially created snapshot has been deleted.
+				delete_snapshot(app_config)
+				request_emulator_shutdown(app_config)
+
+				if emulator_pid.value is not None and emulator_pid.value > 0:
+					try:
+						logger.info('Emulator process might still be alive, sending KILL signal...')
+						logger.info('')
+						os.kill(emulator_pid.value, signal.SIGKILL)
+					except Exception as e2:
+						logger.info(e2)
+		else:
+			logger.info('Running in interactive mode - please confirm progress by hitting the Enter key when requested.')
+			logger.info('')
+			emulator_proc = boot_emulator(app_config)
+
+			wait_for_emulator_boot = WaitForEmulatorBoot('wait_for_emulator_boot', app_config)
+			wait_for_emulator_boot.execute('wait_for_emulator_boot')
+
+			logger.info('Opening SplatNet3...')
+			subprocess.run(f'{app_config.emulator_config.adb_path} shell am start https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808',
+						   shell=True,
+						   stdout=subprocess.PIPE,
+						   stderr=subprocess.PIPE)
+			logger.info('')
+			logger.info('Opened SplatNet3. Please press enter once you see EITHER the SplatNet3 Main Menu OR an error message inside SplatNet3 (yellow title, white text, grey background). If necessary, you can also update the Nintendo Switch App.')
+			sleep(2)
+
+			input("Press the Enter key after SplatNet3 has been opened and is either displaying the main menu or an error message: ")
+
+			screenshot_path = save_splanet3_screenshot(app_config)
+
+			create_snapshot(app_config)
+
+			logger.info('All done. No further inputs will be required from here on.')
+
+			close_nsa = CloseNSA('close_nsa', app_config)
+			close_nsa.execute('close_nsa')
+
+			request_emulator_shutdown(app_config)
+			wait_for_shutdown(emulator_proc)
+
+			# extract tokens from RAM dump
+			g_token, bullet_token, session_token, user_agent, web_view_version, na_country, na_language, app_language = search_for_tokens(app_config)
+			delete_snapshot(app_config)
+
+			if g_token is not None and bullet_token is not None and session_token is not None and na_country is not None:
+				# do a webrequest to see whether they work
+				if (app_config.token_config.validate_splat3_homepage
+					and app_config.token_config.extract_g_token and app_config.token_config.validate_g_token
+					and app_config.token_config.extract_bullet_token and app_config.token_config.validate_bullet_token):
+
+					if not is_homepage_reachable(g_token, bullet_token, user_agent, web_view_version, na_country, na_language, app_language):
+						logger.info('tokens were found but are invalid, attempt did not work')
+						logger.info('')
+
+				create_target_file(app_config, g_token, bullet_token, session_token, user_agent, web_view_version, na_country, na_language, app_language)
+
+				if args.console_out:
+					print(json.dumps({
+						'g_token': g_token,
+						'bullet_token': bullet_token,
+						'session_token': session_token,
+						'user_agent': user_agent,
+						'web_view_version': web_view_version,
+						'na_country': na_country,
+						'na_language': na_language,
+						'app_language': app_language
+					}))
+
+				log_splatnet3_screenshot_message(screenshot_path)
+				sys.exit(SUCCESS)
+			else:
+				logger.info('not all tokens could be found, attempt did not work')
+				logger.info('')
 
 	ended = time.time()
 	elapsed = ended - start_time
@@ -250,6 +327,27 @@ def main():
 	logger.info('')
 	sys.exit(NOT_ALL_TOKENS_FOUND)
 
+
+def save_splanet3_screenshot(app_config: AppConfig) -> str:
+	current_time = datetime.datetime.now()
+	current_script_path = os.path.dirname(os.path.realpath(__file__))
+	screenshot_path = os.path.join(current_script_path, f'{current_time.strftime('%Y-%m-%d_%H-%M-%S')}.png')
+	logger.info(f'Creating a Screenshot of the current screen with SplatNet3 opened...')
+	subprocess.run(f'{app_config.emulator_config.adb_path} exec-out screencap -p > {screenshot_path}',
+				   shell=True,
+				   stdout=subprocess.PIPE,
+				   stderr=subprocess.PIPE)
+	logger.info(f'Screenshot saved at "{screenshot_path}"')
+
+	return screenshot_path
+
+def log_splatnet3_screenshot_message(screenshot_path):
+	logger.info('')
+	logger.info('!!! ATTENTION !!!')
+	logger.info(f'A screenshot with SplatNet3 opened was saved to "{screenshot_path}".')
+	logger.info(f'Please send this screenshot to strohkoenig so he can analyse it and understand why the automatic extraction did not work.')
+	logger.info(f'You can do so by either sending it to strohkoenig on Discord or by opening or adding to an issue on GitHub.')
+	logger.info(f'Thank you for helping with improving this project!')
 
 if __name__ == '__main__':
 	main()

--- a/quickstart_s3s_guide.md
+++ b/quickstart_s3s_guide.md
@@ -214,6 +214,12 @@ For example, you can do this:
 # print all available commands
 python run_s3s.py --help
 
+# IF THE REGULAR EXTRACTION DOES NOT WORK, RUN INTERACTIVE MODE
+# SEE INFORMATION BELOW UNDER "Interactive Mode" SECTION
+python run_s3s.py -im
+python run_s3s.py -im --getseed
+python run_s3s.py -im -r -M
+
 # Lean's Gear Seed Checker
 # export a gear file which you can upload to Lean's Gear Seed Checker
 # IMPORTANT: please update s3s to a version released on August 19th 2025 or later if --getseed fails
@@ -227,6 +233,21 @@ python run_s3s.py -r
 # upload recent battles to stat.ink and activate monitoring mode
 python run_s3s.py -r -M
 ```
+
+## Interactive Mode
+Emulator settings and display can vary throughout different operating systems and installations. For this reason, the fully automated token generation might fail. Fixing these issues is difficult because I cannot reproduce them easily on my computer, where everyhing works fine.
+
+For this reason, Interactive Mode was added. It is the same as the regular extraction, however the user has to manually press the Enter key inside the Terminal as soon as SplatNet3 is fully loaded (which means either the main menu or an Error message is displayed). When triggered, a screenshot will be created and saved in the main directory. If you were experiencing issues with running the regular, automatic method before, please consider sending the screenshot to the developer via discord (strohkoenig) or an issue on GitHub.
+
+It can be triggered by adding `-im` to the command:
+```shell
+# run token extraction in interactive mode
+python main.py -im
+
+# let run_s3s.py start extraction in interactive mode if necessary
+python run_s3s.py -im [INSERT S3S ARGUMENTS HERE]
+```
+
 
 ### outdated: workaround for the `--getseed` bug
 The `--getseed` bug in s3s has been fixed on August 19th 2025. A workaround is not necessary anymore after updating s3s.

--- a/readme.md
+++ b/readme.md
@@ -112,11 +112,27 @@ Here is a list of some important files and directories of the project structure
   - `utils/template_utils.py`: this file fills the `config/template.txt` file with found tokens and stores it to `config.txt`
   - `utils/update_utils.py`: this file manages everything related to updating the project: update fetching, notifications and update execution
 
+## Interactive Mode
+Emulator settings and display can vary throughout different operating systems and installations. For this reason, the fully automated token generation might fail. Fixing these issues is difficult because I cannot reproduce them easily on my computer, where everyhing works fine.
+
+For this reason, Interactive Mode was added. It is the same as the regular extraction, however the user has to manually press the Enter key inside the Terminal as soon as SplatNet3 is fully loaded (which means either the main menu or an Error message is displayed). When triggered, a screenshot will be created and saved in the main directory. If you were experiencing issues with running the regular, automatic method before, please consider sending the screenshot to the developer via discord (strohkoenig) or an issue on GitHub.
+It can be triggered by adding `-im` to the command:
+```shell
+# run token extraction in interactive mode
+python main.py -im
+
+# let run_s3s.py start extraction in interactive mode if necessary
+python run_s3s.py -im [INSERT S3S ARGUMENTS HERE]
+```
+
 ## main.py basic commands
 Currently, `main.py` offers three main commands you can execute: 
 ```shell
 # run token extraction
 python main.py
+
+# run token extraction in interactive mode (= you have to press Enter once SplatNet3 is opened), see Interactive Mode section
+python main.py -im
 
 # boot emulator (blocks until emulator shuts down)
 python main.py --emu

--- a/run_s3s.py
+++ b/run_s3s.py
@@ -62,7 +62,13 @@ def main():
 		sys.argv += ['--help']
 		logger.info('')
 
-	s3s_args = ' '.join(['--norefresh', config['s3s_refresh_rc']] + sys.argv[1:])
+	all_args = sys.argv[1:]
+	run_interactive_mode = False
+	if '-im' in all_args:
+		run_interactive_mode = True
+		all_args = [i for i in all_args if i != '-im']
+
+	s3s_args = ' '.join(['--norefresh', config['s3s_refresh_rc']] + all_args)
 
 	while True:
 		# 1. prepare s3s run
@@ -127,7 +133,7 @@ def main():
 			config['stu_update'] = False
 
 		# 4. run splatnet3-token-util and act according to result
-		stu_proc = subprocess.run(f'{config["python_command"]} main.py',
+		stu_proc = subprocess.run(f'{config["python_command"]} main.py{' -im' if run_interactive_mode else ''}',
 								  shell=True)
 
 		logger.info('')


### PR DESCRIPTION
- add "-im" flag to both main.py and run_s3s.py
- this flag triggers a manual mode where extraction works like usual but the recognition whether SplatNet3 is open or not is disabled. Instead, users have to manually hit the Enter key as soon as the extraction can happen. Apart from that, everything else works normally.
- add documentation to readme.md and quickstart_s3s_guide.md
- additionally, extract a screenshot of SplatNet3 before closing the emulator both when running into the timeout as well as using the manual method. Ask user to send the screenshot to the developers to be able to finally solve the timeout issues.