### PR TITLE
fix: 🐛 fix bug that emulator would not boot if a space is in the emulator path

### DIFF
--- a/main.py
+++ b/main.py
@@ -263,7 +263,7 @@ def main():
 			wait_for_emulator_boot.execute('wait_for_emulator_boot')
 
 			logger.info('Opening SplatNet3...')
-			subprocess.run(f'{app_config.emulator_config.adb_path} shell am start https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808',
+			subprocess.run(f'"{app_config.emulator_config.adb_path}" shell am start https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808',
 						   shell=True,
 						   stdout=subprocess.PIPE,
 						   stderr=subprocess.PIPE)
@@ -333,7 +333,7 @@ def save_splanet3_screenshot(app_config: AppConfig) -> str:
 	current_script_path = os.path.dirname(os.path.realpath(__file__))
 	screenshot_path = os.path.join(current_script_path, f'{current_time.strftime('%Y-%m-%d_%H-%M-%S')}.png')
 	logger.info(f'Creating a Screenshot of the current screen with SplatNet3 opened...')
-	subprocess.run(f'{app_config.emulator_config.adb_path} exec-out screencap -p > {screenshot_path}',
+	subprocess.run(f'"{app_config.emulator_config.adb_path}" exec-out screencap -p > "{screenshot_path}"',
 				   shell=True,
 				   stdout=subprocess.PIPE,
 				   stderr=subprocess.PIPE)

--- a/run_s3s.py
+++ b/run_s3s.py
@@ -77,24 +77,24 @@ def main():
 		logger.info('###########')
 		logger.info('')
 
-		logger.info(f'Running s3s with command "{config["python_command"]} {os.path.join(config["s3s_directory"], "s3s.py")} {s3s_args}"')
+		logger.info(f'Running s3s with command `"{config["python_command"]}" {os.path.join(config["s3s_directory"], "s3s.py")} {s3s_args}`')
 		logger.info('')
 
 		if config['s3s_update']:
-			logger.info(f'1/2 Running s3s update with command "{config["git_command"]} pull"')
-			subprocess.run(f'{config["git_command"]} pull',
+			logger.info(f'1/2 Running s3s update with command `"{config["git_command"]}" pull`')
+			subprocess.run(f'"{config["git_command"]}" pull',
 						   cwd=config['s3s_directory'],
 						   shell=True)
 			logger.info('')
-			logger.info(f'2/2 Running s3s update with command "{config["pip_command"]} install -r requirements.txt"')
-			subprocess.run(f'{config["pip_command"]} install -r requirements.txt',
+			logger.info(f'2/2 Running s3s update with command `"{config["pip_command"]}" install -r requirements.txt`')
+			subprocess.run(f'"{config["pip_command"]}" install -r requirements.txt',
 						   cwd=config['s3s_directory'],
 						   shell=True)
 			logger.info('')
 			config['s3s_update'] = False
 
 		# 2. run s3s and store return code
-		s3s_proc = subprocess.run(f'{config["python_command"]} {os.path.join(config["s3s_directory"], "s3s.py")} {s3s_args}',
+		s3s_proc = subprocess.run(f'"{config["python_command"]}" "{os.path.join(config["s3s_directory"], "s3s.py")}" {s3s_args}',
 								  cwd=config['s3s_directory'],
 								  shell=True)
 
@@ -122,18 +122,18 @@ def main():
 		logger.info('')
 
 		if config['stu_update']:
-			logger.info(f'1/2 Running splatnet3-token-util update with command "{config["git_command"]} pull"')
-			subprocess.run(f'{config["git_command"]} pull',
+			logger.info(f'1/2 Running splatnet3-token-util update with command `"{config["git_command"]}" pull`')
+			subprocess.run(f'"{config["git_command"]}" pull',
 						   shell=True)
 			logger.info('')
-			logger.info(f'2/2 Running splatnet3-token-util update with command "{config["pip_command"]} install -r requirements.txt"')
-			subprocess.run(f'{config["pip_command"]} install -r requirements.txt',
+			logger.info(f'2/2 Running splatnet3-token-util update with command `"{config["pip_command"]}" install -r requirements.txt`')
+			subprocess.run(f'"{config["pip_command"]}" install -r requirements.txt',
 						   shell=True)
 			logger.info('')
 			config['stu_update'] = False
 
 		# 4. run splatnet3-token-util and act according to result
-		stu_proc = subprocess.run(f'{config["python_command"]} main.py{' -im' if run_interactive_mode else ''}',
+		stu_proc = subprocess.run(f'"{config["python_command"]}" main.py{' -im' if run_interactive_mode else ''}',
 								  shell=True)
 
 		logger.info('')

--- a/steps/block_while.py
+++ b/steps/block_while.py
@@ -67,7 +67,7 @@ class BlockWhile:
 			time.sleep(int(parsed_args.duration) / 1000.0)
 
 			self.logger.info(f'Comparing screenshot "{parsed_args.actual}" to base screenshot "{parsed_args.template}" with cutoff {parsed_args.cutoff}.')
-			subprocess.run(f'{self.app_config.emulator_config.adb_path} exec-out screencap -p > {parsed_args.actual}',
+			subprocess.run(f'"{self.app_config.emulator_config.adb_path}" exec-out screencap -p > "{parsed_args.actual}"',
 						   shell=True,
 						   stdout=subprocess.PIPE,
 						   stderr=subprocess.PIPE)

--- a/steps/close_nsa.py
+++ b/steps/close_nsa.py
@@ -43,7 +43,7 @@ class CloseNSA:
 		for i in range(int(parsed_args.max_attempts)):
 			self.logger.info(f'Closing Nintendo Switch App - attempt {i + 1}/{parsed_args.max_attempts}')
 
-			subprocess.run(f'{self.app_config.emulator_config.adb_path} shell am force-stop com.nintendo.znca',
+			subprocess.run(f'"{self.app_config.emulator_config.adb_path}" shell am force-stop com.nintendo.znca',
 						   shell=True,
 						   stdout=subprocess.PIPE,
 						   stderr=subprocess.PIPE)
@@ -53,7 +53,7 @@ class CloseNSA:
 			while not closed and time.time() - start_time < int(parsed_args.max_wait_secs):
 				time.sleep(int(parsed_args.duration) / 1000.0)
 
-				nsa_closed_proc = subprocess.Popen(f'{self.app_config.emulator_config.adb_path} shell dumpsys activity -p com.nintendo.znca activities',
+				nsa_closed_proc = subprocess.Popen(f'"{self.app_config.emulator_config.adb_path}" shell dumpsys activity -p com.nintendo.znca activities',
 												   shell=True,
 												   stdout=subprocess.PIPE,
 												   stderr=subprocess.PIPE)

--- a/steps/create_screenshot.py
+++ b/steps/create_screenshot.py
@@ -36,7 +36,7 @@ class CreateScreenshot:
 		os.makedirs(os.path.dirname(parsed_args.path), exist_ok=True)
 
 		while not os.path.exists(parsed_args.path):
-			subprocess.run(f'{self.app_config.emulator_config.adb_path} exec-out screencap -p > {parsed_args.path}',
+			subprocess.run(f'"{self.app_config.emulator_config.adb_path}" exec-out screencap -p > "{parsed_args.path}"',
 						   shell=True,
 						   stdout=subprocess.PIPE,
 						   stderr=subprocess.PIPE)

--- a/steps/execute_while.py
+++ b/steps/execute_while.py
@@ -73,7 +73,7 @@ class ExecuteWhile:
 			time.sleep(int(parsed_args.duration) / 1000.0)
 
 			self.logger.info(f'Comparing screenshot "{parsed_args.actual}" to base screenshot "{parsed_args.template}" with cutoff {parsed_args.cutoff}.')
-			subprocess.run(f'{self.app_config.emulator_config.adb_path} exec-out screencap -p > {parsed_args.actual}',
+			subprocess.run(f'"{self.app_config.emulator_config.adb_path}" exec-out screencap -p > "{parsed_args.actual}"',
 						   shell=True,
 						   stdout=subprocess.PIPE,
 						   stderr=subprocess.PIPE)

--- a/steps/open_splatnet3.py
+++ b/steps/open_splatnet3.py
@@ -69,7 +69,7 @@ class OpenSplatNet3:
 		for i in range(int(parsed_args.max_attempts)):
 			self.logger.info(f'Open SplatNet3 app - attempt {i + 1}/{parsed_args.max_attempts}')
 
-			subprocess.run(f'{self.app_config.emulator_config.adb_path} shell am start https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808',
+			subprocess.run(f'"{self.app_config.emulator_config.adb_path}" shell am start https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808',
 						   shell=True,
 						   stdout=subprocess.PIPE,
 						   stderr=subprocess.PIPE)
@@ -79,7 +79,7 @@ class OpenSplatNet3:
 			while not found and time.time() - start_time < int(parsed_args.max_wait_secs):
 				time.sleep(int(parsed_args.duration) / 1000.0)
 
-				subprocess.run(f'{self.app_config.emulator_config.adb_path} exec-out screencap -p > {parsed_args.actual}',
+				subprocess.run(f'"{self.app_config.emulator_config.adb_path}" exec-out screencap -p > "{parsed_args.actual}"',
 							   shell=True,
 							   stdout=subprocess.PIPE,
 							   stderr=subprocess.PIPE)

--- a/steps/press_power_button_long.py
+++ b/steps/press_power_button_long.py
@@ -26,7 +26,7 @@ class PressPowerButtonLong:
 
 	def execute(self, args):
 		self.logger.info(f'Pressing the power button for a long time.')
-		subprocess.run(f'{self.app_config.emulator_config.adb_path} shell input keyevent --longpress KEYCODE_POWER',
+		subprocess.run(f'"{self.app_config.emulator_config.adb_path}" shell input keyevent --longpress KEYCODE_POWER',
 					   shell=True,
 					   stdout=subprocess.PIPE,
 					   stderr=subprocess.PIPE)

--- a/steps/search_and_tap_center.py
+++ b/steps/search_and_tap_center.py
@@ -104,7 +104,7 @@ class SearchAndTapCenter:
 				if not execute_immediately:
 					self.logger.info(
 						f'Searching for image from base screenshot "{parsed_args.template}" in screenshot "{parsed_args.actual}" with cutoff {parsed_args.cutoff}.')
-					subprocess.run(f'{self.app_config.emulator_config.adb_path} exec-out screencap -p > {parsed_args.actual}',
+					subprocess.run(f'"{self.app_config.emulator_config.adb_path}" exec-out screencap -p > "{parsed_args.actual}"',
 								   shell=True,
 								   stdout=subprocess.PIPE,
 								   stderr=subprocess.PIPE)

--- a/steps/shutdown_emu.py
+++ b/steps/shutdown_emu.py
@@ -42,7 +42,7 @@ class ShutdownEmulator:
 		for i in range(int(parsed_args.max_attempts)):
 			self.logger.info(f'Shutting down emulator - attempt {i + 1}/{parsed_args.max_attempts}')
 
-			subprocess.run(f'{self.app_config.emulator_config.adb_path} shell reboot -p',
+			subprocess.run(f'"{self.app_config.emulator_config.adb_path}" shell reboot -p',
 						   shell=True,
 						   stdout=subprocess.PIPE,
 						   stderr=subprocess.PIPE)
@@ -53,7 +53,7 @@ class ShutdownEmulator:
 			while not stopped and time.time() - start_time < int(parsed_args.max_wait_secs):
 				time.sleep(int(parsed_args.duration) / 1000.0)
 
-				currently_opened_app_proc = subprocess.Popen(f'{self.app_config.emulator_config.adb_path} devices',
+				currently_opened_app_proc = subprocess.Popen(f'"{self.app_config.emulator_config.adb_path}" devices',
 															 shell=True,
 															 stdout=subprocess.PIPE,
 															 stderr=subprocess.PIPE)

--- a/steps/swipe.py
+++ b/steps/swipe.py
@@ -35,7 +35,7 @@ class Swipe:
 
 		self.logger.info(f'Swiping from position ({parsed_args.x1}, {parsed_args.y1}) to ({parsed_args.x2}, {parsed_args.y2}) in {parsed_args.duration} milliseconds.')
 		subprocess.run(
-			f'{self.app_config.emulator_config.adb_path} shell input swipe {parsed_args.x1} {parsed_args.y1} {parsed_args.x2} {parsed_args.y2} {parsed_args.duration}',
+			f'"{self.app_config.emulator_config.adb_path}" shell input swipe {parsed_args.x1} {parsed_args.y1} {parsed_args.x2} {parsed_args.y2} {parsed_args.duration}',
 			shell=True,
 			stdout=subprocess.PIPE,
 			stderr=subprocess.PIPE)

--- a/steps/tap.py
+++ b/steps/tap.py
@@ -31,7 +31,7 @@ class Tap:
 		parsed_args = self.parser.parse_args(only_args)
 
 		self.logger.info(f'Tapping position ({parsed_args.x}, {parsed_args.y}).')
-		subprocess.run(f'{self.app_config.emulator_config.adb_path} shell input tap {parsed_args.x} {parsed_args.y}',
+		subprocess.run(f'"{self.app_config.emulator_config.adb_path}" shell input tap {parsed_args.x} {parsed_args.y}',
 					   shell=True,
 					   stdout=subprocess.PIPE,
 					   stderr=subprocess.PIPE)

--- a/steps/type.py
+++ b/steps/type.py
@@ -30,7 +30,7 @@ class Type:
 		parsed_args = self.parser.parse_args(only_args)
 
 		self.logger.info(f'Typing text "{parsed_args.text}".')
-		subprocess.run(f'{self.app_config.emulator_config.adb_path} shell input text "{parsed_args.text.replace(" ", "%s")}"',
+		subprocess.run(f'"{self.app_config.emulator_config.adb_path}" shell input text "{parsed_args.text.replace(" ", "%s")}"',
 					   shell=True,
 					   stdout=subprocess.PIPE,
 					   stderr=subprocess.PIPE)

--- a/steps/wait_for_emulator_boot.py
+++ b/steps/wait_for_emulator_boot.py
@@ -44,7 +44,7 @@ class WaitForEmulatorBoot:
 		while not found and time.time() - start_time < int(parsed_args.max_wait_secs):
 			time.sleep(int(parsed_args.duration) / 1000.0)
 
-			emulator_boot_check_proc = subprocess.Popen(f'{self.app_config.emulator_config.adb_path} shell dumpsys activity recents',
+			emulator_boot_check_proc = subprocess.Popen(f'"{self.app_config.emulator_config.adb_path}" shell dumpsys activity recents',
 														shell=True,
 														stdout=subprocess.PIPE,
 														stderr=subprocess.PIPE)

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def __search_path(find_app_command, app_name):
-	find_proc = Popen(f'{find_app_command} {app_name}', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	find_proc = Popen(f'"{find_app_command}" "{app_name}"', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 	for line in io.TextIOWrapper(find_proc.stdout, encoding="utf-8"):
 		if not line:

--- a/utils/emulator_utils.py
+++ b/utils/emulator_utils.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def boot_emulator(app_config: AppConfig):
 	logger.info('Booting emulator...')
 	emulator_proc = Popen(
-		f'{app_config.emulator_config.emulator_path} {app_config.emulator_config.get_emulator_boot_args()}',
+		f'"{app_config.emulator_config.emulator_path}" {app_config.emulator_config.get_emulator_boot_args()}',
 		shell=True,
 		stdout=subprocess.PIPE,
 		stderr=subprocess.PIPE)
@@ -44,7 +44,7 @@ def boot_emulator(app_config: AppConfig):
 
 
 def get_emulator_name(app_config: AppConfig):
-	emulator_devices_proc = Popen(f'{app_config.emulator_config.adb_path} devices',
+	emulator_devices_proc = Popen(f'"{app_config.emulator_config.adb_path}" devices',
 								  shell=True,
 								  stdout=subprocess.PIPE,
 								  stderr=subprocess.PIPE)
@@ -72,7 +72,7 @@ def run_adb(app_config: AppConfig, command: str):
 	emulator_name = get_emulator_name(app_config)
 
 	# run command
-	subprocess.run(f'{app_config.emulator_config.adb_path} -s {emulator_name} {command}',
+	subprocess.run(f'"{app_config.emulator_config.adb_path}" -s "{emulator_name}" {command}',
 				   shell=True,
 				   stderr=sys.stderr,
 				   stdout=sys.stderr)
@@ -96,7 +96,7 @@ def create_snapshot(app_config: AppConfig):
 		emulator_name = get_emulator_name(app_config)
 
 		# do snapshot
-		subprocess.run(f'{app_config.emulator_config.adb_path} -s {emulator_name} emu avd snapshot save {app_config.emulator_config.snapshot_name}',
+		subprocess.run(f'"{app_config.emulator_config.adb_path}" -s "{emulator_name}" emu avd snapshot save {app_config.emulator_config.snapshot_name}',
 					   shell=True,
 					   stdout=sys.stderr,
 					   stderr=sys.stderr)
@@ -120,7 +120,7 @@ def request_emulator_shutdown(app_config: AppConfig):
 	emulator_name = get_emulator_name(app_config)
 
 	# do snapshot
-	subprocess.run(f'{app_config.emulator_config.adb_path} -s {emulator_name} emu kill',
+	subprocess.run(f'"{app_config.emulator_config.adb_path}" -s "{emulator_name}" emu kill',
 				   shell=True,
 				   stdout=sys.stderr,
 				   stderr=sys.stderr)

--- a/utils/update_utils.py
+++ b/utils/update_utils.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def check_for_update(app_config: AppConfig):
 	git_fetch_proc = Popen(
-		f'{app_config.update_config.git_command} fetch',
+		f'"{app_config.update_config.git_command}" fetch',
 		shell=True,
 		stdout=subprocess.PIPE,
 		stderr=subprocess.STDOUT)
@@ -31,7 +31,7 @@ def check_for_update(app_config: AppConfig):
 		logger.error('')
 
 	git_status_proc = Popen(
-		f'{app_config.update_config.git_command} status -sb',
+		f'"{app_config.update_config.git_command}" status -sb',
 		shell=True,
 		stdout=subprocess.PIPE,
 		stderr=subprocess.STDOUT)
@@ -76,7 +76,7 @@ def update(app_config: AppConfig):
 	logger.info(f'Update in progress...')
 
 	update_error_command = None
-	current_command = f'{app_config.update_config.git_command} pull'
+	current_command = f'"{app_config.update_config.git_command}" pull'
 
 	logger.info(f'')
 	logger.info(f'running command: `{current_command}`')
@@ -98,7 +98,7 @@ def update(app_config: AppConfig):
 			logger.error(line.strip())
 
 	if update_error_command is None:
-		current_command = f'{app_config.update_config.pip_command} install -r requirements.txt'
+		current_command = f'"{app_config.update_config.pip_command}" install -r requirements.txt'
 
 		logger.info(f'')
 		logger.info(f'running command: `{current_command}`')


### PR DESCRIPTION
Escape all occurrences of paths with `"` character to ensure they still work even with spaces

#16 